### PR TITLE
fix python requirement so we don't require a python 2.7 newer than 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     package_dir={'': 'src'},
     include_package_data=True,
     zip_safe=False,
-    python_requires="==2.7, >=3.6",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
     install_requires=[
         'setuptools',
         # -*- Extra requirements: -*-


### PR DESCRIPTION
"==2.7, >=3.6" doesn't possibly match anything
instead, require something newer than 2.7 that isn't one of 3.0 to 3.5
copy-pasted from https://github.com/collective/collective.exportimport/blob/main/setup.py#L77